### PR TITLE
Unrecog bug fix

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -184,7 +184,7 @@ class ScreenShot:
         for i, pt in enumerate(item_pts):
             lx, _ = self.find_edge(self.img_th[pt[1]: pt[3],
                                                pt[0]: pt[2]], reverse=True)
-            item_img_th = self.img_th[pt[1]: pt[3] - 20,
+            item_img_th = self.img_th[pt[1]: pt[3] - 30,
                                           pt[0] + lx: pt[2] + lx]
             if self.is_empty_box(item_img_th):
                 break
@@ -646,7 +646,7 @@ class Item:
                 else:
                     flag = True
 
-        if flag:
+        if flag is False:
             pts.append(pt)
         return pts
 
@@ -1089,7 +1089,7 @@ class Item:
         """
         font_size = FONTSIZE_UNDEFINED
 
-        if self.fileextention.lower() == '.png' and mode == 'jp':
+        if self.fileextention.lower() == '.png':
             bonus_pts = self.detect_bonus_char()
             self.bonus = self.read_item(bonus_pts, debug)
             # フォントサイズを決定


### PR DESCRIPTION
1. The part that recognizes the bonus in PNG was enbuged, so that's fixed. Changed the NA version back to use the original routines for PNGs.
2. Return (drop_count)-1 if there is something that is overlay non-number object for the drop count in the upper right corner of the screenshot.
3. The correct item is recognized even if drop_count is -1.

1. PNGでボーナスを認識する箇所がエンバグしていたので修正。NA版を元のPNG用ルーチンを使うように戻した
2. スクリーンショットの右上のドロップ数にオーバーレイする数字でない何かがある場合、(drop_count)-1を返すようにした
3. drop_count　が-1の場合でも正しいアイテムを認識するようにした