### PR TITLE
前の頁の重複したアイテムをカットするタイミングの間違い

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1603,6 +1603,8 @@ def get_output(filenames, args):
                     td = datetime.timedelta(days=1)
                 else:
                     td = dt - prev_datetime
+                if sc.pages - sc.pagenum == 0:
+                    sc.itemlist = sc.itemlist[14-(sc.lines+2) % 3*7:]
                 if prev_itemlist == sc.itemlist:
                     if (sc.total_qp != 999999999
                         and sc.total_qp == prev_total_qp) \
@@ -1631,8 +1633,6 @@ def get_output(filenames, args):
                     fileoutput.append({'filename': 'missing'})
                     all_list.append([])
 
-                if sc.pages - sc.pagenum == 0:
-                    sc.itemlist = sc.itemlist[14-(sc.lines+2) % 3*7:]
                 all_list.append(sc.itemlist)
 
                 prev_pages = sc.pages


### PR DESCRIPTION
#183 の修正
#181 の修正で、class ScreenShotは複数ページで構成されるスクショのアイテムの重複除去をしなくなり、get_output()内で行うようにしたが、duplicateの判定時、重複を除去した前の頁のアイテムと重複を除去しない現在の頁のアイテムを比較していたためduplicateと出力されなくなっていた