### PR TITLE
fix cutting gamescreen

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -413,6 +413,8 @@ class ScreenShot:
             if y1 == y2 and y1 < height/2:
                 if upper_y < y1:
                     upper_y = y1
+        logger.debug("left_x: %d", left_x)
+        logger.debug("upper_y: %d", upper_y)
 
         # Detect Right line
         # Avoid catching the line of the scroll bar
@@ -428,6 +430,23 @@ class ScreenShot:
             if x1 == x2 and x1 > width*3/4 and (y1 < upper_y or y2 < upper_y):
                 if right_x > x1:
                     right_x = x1
+        if right_x > width - 80:
+            logger.warning("right_x detection failed.")
+            # Redefine right_x from the pseudo_bottom_y
+            pseudo_bottom_y = height
+            for line in lines:
+                x1, y1, x2, y2 = line[0]
+                if y1 == y2 and y1 > height/2 and (x1 < width/2):
+                    if pseudo_bottom_y > y1:
+                        pseudo_bottom_y = y1
+            logger.debug("pseudo_bottom_y: %d", pseudo_bottom_y)
+            for line in lines:
+                x1, y1, x2, y2 = line[0]
+                if x1 == x2 and x1 > width*3/4 \
+                   and (y1 > pseudo_bottom_y or y2 > pseudo_bottom_y):
+                    if right_x > x1:
+                        right_x = x1
+        logger.debug("right_x: %d", right_x)
 
         # Detect Bottom line
         # Changed the underline of cut image to use the top of Next button.
@@ -436,6 +455,7 @@ class ScreenShot:
             if y1 == y2 and y1 > height/2 and (x1 > right_x or x2 > right_x):
                 if bottom_y > y1:
                     bottom_y = y1
+        logger.debug("bottom_y: %d", bottom_y)
 
         if logger.isEnabledFor(logging.DEBUG):
             tmpimg = self.img_rgb_orig[upper_y: bottom_y, left_x: right_x]
@@ -451,7 +471,6 @@ class ScreenShot:
         scale = bottom_y - upper_y
         upper_y = upper_y - int(177*scale/847)
         bottom_y = bottom_y + int(124*scale/847)
-
         game_screen = self.img_rgb_orig[upper_y: bottom_y, left_x: right_x]
         return game_screen
 


### PR DESCRIPTION
If detection of a straight line from the top of the scrollbar fails, it is detected from the bottom of the scrollbar.