### PR TITLE
fix #219

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -619,7 +619,7 @@ class ScreenShot:
             area = cv2.contourArea(cnt)
             pt = [ret[0], ret[1], ret[0] + ret[2], ret[1] + ret[3]]
             if ret[2] < int(w/2) and area > 80 and ret[1] < h/2 \
-                    and 0.35 < ret[2]/ret[3] < 0.85 and ret[3] > h * 0.45:
+                    and 0.3 < ret[2]/ret[3] < 0.85 and ret[3] > h * 0.45:
                 flag = False
                 for p in item_pts:
                     if has_intersect(p, pt):
@@ -651,7 +651,7 @@ class ScreenShot:
         for pt in item_pts:
             test = []
 
-            tmpimg = im_th[pt[1]:pt[3], pt[0]:pt[2]]
+            tmpimg = im_th[pt[1]:pt[3], pt[0]-1:pt[2]+1]
             tmpimg = cv2.resize(tmpimg, (win_size))
             hog = cv2.HOGDescriptor(win_size, block_size,
                                     block_stride, cell_size, bins)
@@ -667,7 +667,7 @@ class ScreenShot:
         """
         宝箱数をOCRする関数
         """
-        pt = [1443, 20, 1505, 61]
+        pt = [1448, 20, 1505, 54]
         img_num = self.img_th[pt[1]:pt[3], pt[0]:pt[2]]
         im_th = cv2.bitwise_not(img_num)
         h, w = im_th.shape[:2]


### PR DESCRIPTION
### 修正点1
#219 の修正
ドロップ数の取得位置がいつの間にかずれていたため情報ウィンドウの切り出し方が下図のようになっていた
そのため25と認識するところを75と認識していた

![image](https://user-images.githubusercontent.com/62515228/96403531-a95c2900-1213-11eb-944e-e0585bf356e7.png)

修正後

![image](https://user-images.githubusercontent.com/62515228/96403572-b6791800-1213-11eb-949a-bc3a7e4afe6b.png)

### 修正点2
下図のドロップ数を7と認識していたため修正
1を検出できるように閾値を変更
![solutian3](https://user-images.githubusercontent.com/62515228/96403755-1bcd0900-1214-11eb-8e9f-4fd5a06cd9f0.jpg)
