### PR TITLE
fix line detection for broken line

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -545,7 +545,7 @@ class ScreenShot:
         # it catches the line of the item.
         lines = cv2.HoughLinesP(canny_img, rho=1, theta=np.pi/2,
                                 threshold=80, minLineLength=int(height/5),
-                                maxLineGap=6)
+                                maxLineGap=9)
 
         left_x = upper_y = b_line_y = 0
         right_x = width


### PR DESCRIPTION
https://fgojunks.max747.org/fgosccnt/results/e4df4a60-8cd8-4285-833f-37780b1ae80f/
で破線の判定に失敗するため not valid になる問題の修正