### PR TITLE
fix ocr_dcnt

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -686,8 +686,8 @@ class ScreenShot:
             dcnt_old = self.img_rgb_orig[upper_dyo: bottom_dyo,
                                          left_dxo: right_dxo]
         if upper_lower_blue_border:
-            left_dx = left_x + int(1470*scale/924)
-            right_dx = left_dx + int(60*scale/924)
+            left_dx = left_x + int(1467*scale/924)
+            right_dx = left_dx + int(63*scale/924)
         else:
             left_dx = left_x + int(1400*scale/924)
             right_dx = left_dx + int(305*scale/924)


### PR DESCRIPTION
https://fgojunks.max747.org/fgosccnt/results/fbf9232b-c6f8-4f1d-ac09-3424b8450c8e/
のnot validの解消