### PR TITLE
fix #304

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -265,7 +265,7 @@ def get_coodinates(img: ndarray,
     for cnt in contours:
         _, _, w, h = cv2.boundingRect(cnt)
         area = cv2.contourArea(cnt)
-        if 1.82 < w/h < 1.83 and area > height / 2 * width / 2:
+        if 1.81 < w/h < 1.83 and area > height / 2 * width / 2:
             contours2.append(cnt)
     if len(contours2) == 0:
         raise ValueError("Game screen not found.")


### PR DESCRIPTION
gamescreenを判定するための縦横の比率の閾値が厳しすぎたため、正常な画像までエラーになるため緩く変更