### PR TITLE
csv2counter: json フォーマットに警告メッセージを含める

### DIFF
--- a/csv2counter.py
+++ b/csv2counter.py
@@ -106,7 +106,7 @@ class QuestReport:
         for line in self.lines:
             formatted_output += f"{line.material}{line.initial}\n"
 
-        formatted_output += "#FGO周回カウンタ http://aoshirobo.net/fatego/rc/\n"
+        formatted_output += "#FGO周回カウンタ https://fgodrop.max747.org/\n"
         if len(self.note) > 0:
             formatted_output += "\n" + self.note
         return formatted_output


### PR DESCRIPTION
```
$ ./csv2counter.py result.csv
###############################################
# WARNING: この処理には以下のエラーがあります #
# 確認せず結果をそのまま使用しないでください #
###############################################
22行目に missing (複数ページの撮影抜け)があります
41行目に missing (複数ページの撮影抜け)があります
44行目に missing (複数ページの撮影抜け)があります
99行目に missing (複数ページの撮影抜け)があります
138行目に missing (複数ページの撮影抜け)があります
###############################################
【第三関門 ザ・マッシュルーム】100周
礼装0
炉心28
証54
狂秘13
狂輝21
騎モ2
術モ1
殺モ6
狂モ9
手形(x3)529
手形(x4)722
水鉄砲(x3)728
水鉄砲(x4)416
プロテクター(x4)208
#FGO周回カウンタ http://aoshirobo.net/fatego/rc/

証泥UP %
```

これを JSON で出力した場合でも同様に warning が含まれるように改修する。
`has_warnings` と `warning_messages` が増えている。

```
$ ./csv2counter.py --json result.csv
{
  "questname": "第三関門 ザ・マッシュルーム",
  "runs": 100,
  "lines": [
    {
      "material": "礼装",
      "initial": 0
    },
    {
      "material": "炉心",
      "initial": 28
    },
...(snip)...
    {
      "material": "プロテクター(x4)",
      "initial": 208
    }
  ],
  "note": "証泥UP %\n",
  "has_warnings": true,
  "warning_messages": [
    "22行目に missing (複数ページの撮影抜け)があります",
    "41行目に missing (複数ページの撮影抜け)があります",
    "44行目に missing (複数ページの撮影抜け)があります",
    "99行目に missing (複数ページの撮影抜け)があります",
    "138行目に missing (複数ページの撮影抜け)があります"
  ]
}
```